### PR TITLE
Add net461 target

### DIFF
--- a/src/AuthenticodeExaminer/AuthenticodeExaminer.csproj
+++ b/src/AuthenticodeExaminer/AuthenticodeExaminer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Authors>Kevin Jones</Authors>
     <PackageTags>authenticode;keyvault;codesign</PackageTags>
@@ -15,9 +15,14 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.5.1" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="4.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">    
+    <Reference Include="System.Security" />
+  </ItemGroup>
+  
 </Project>

--- a/src/AuthenticodeExaminer/TimestampDecoding.cs
+++ b/src/AuthenticodeExaminer/TimestampDecoding.cs
@@ -1,8 +1,12 @@
 ﻿using AuthenticodeExaminer.Interop;
 using System;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
 using System.Security.Cryptography;
+
+// A FILETIME struct exists in both System.Runtime.InteropServices
+// and System.Runtime.InteropServices.ComTypes for full framework
+// => Explicitly use the the type from ComTypes so project can target net461
+using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
 
 namespace AuthenticodeExaminer
 {


### PR DESCRIPTION
I'd like to use this library in a project that needs to target `net461`.  
Having a build for full framework would makes the package usable for full framework projects even on Visual Studio 2015
